### PR TITLE
Support for maven publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ hs_err_pid*
 target
 .gradle
 build
+
+settings.xml
+

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ build:
 	cd override && ./override.sh
 	mvn package
 
+release:
+	# Will deploy to https://oss.sonatype.org/content/groups/public/com/clever/client/
+	echo "Read http://central.sonatype.org/pages/apache-maven.html"

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,4 @@ build:
 	mvn package
 
 release:
-	# Will deploy to https://oss.sonatype.org/content/groups/public/com/clever/client/
-	echo "Read http://central.sonatype.org/pages/apache-maven.html"
+	mvn clean deploy

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ public void processEvents(DefaultApi api) {
 
 2. Git clone Clever's swagger-api repo (https://github.com/Clever/swagger-api)
 
-3. Install Java
+3. Install Java and Maven
 
 4. In the root directory of the swagger repo run:
 ```
@@ -78,3 +78,10 @@ mvn package
 ```
 
 That will put the jar in: `src/target/swagger-java-client-1.0.0-tests.jar`
+
+
+## Publishing
+
+Use the clever-eng user for Sonatype.
+
+TODO: Add more details

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ That will put the jar in: `src/target/swagger-java-client-1.0.0-tests.jar`
 
 ## Publishing
 
-Use the clever-eng user for Sonatype.
+To publish this library first set up your settings.xml (~/.m2/settings.xml) as described here: http://central.sonatype.org/pages/apache-maven.html. In particular setting up the ossrh profile using the clever-eng username / password and setting up the GPG profile with the security@clever.com PGP key.
 
-TODO: Add more details
+Then run:
+```
+make publish
+```
+
+This will deploy to: https://oss.sonatype.org/content/groups/public/com/clever/client/
+
+The jar will be synced over to the Maven central repository within the next few hours.

--- a/override/pom.xml
+++ b/override/pom.xml
@@ -1,17 +1,110 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.clever</groupId>
-  <artifactId>clever-java-client</artifactId>
+  <groupId>com.clever</groupId>
+  <artifactId>client</artifactId>
   <packaging>jar</packaging>
-  <name>clever-java-client</name>
-  <version>0.1.1</version>
+  <name>Clever Java Client</name>
+  <description>Client Library for the Clever API</description>
+  <url>http://www.clever.com</url>
+  <version>0.2.1</version>
   <prerequisites>
     <maven>2.2.0</maven>
   </prerequisites>
 
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Clever</name>
+      <email>tech-notify@clever.com</email>
+      <organization>Clever</organization>
+      <organizationUrl>http://www.clever.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+      <connection>scm:git:git@github.com:Clever/clever-java.git</connection>
+      <developerConnection>scm:git:git@github.com:Clever/clever-java.git</developerConnection>
+      <url>github.com/Clever/clever-java</url>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+           <serverId>ossrh</serverId>
+           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+           <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+    </plugin>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-javadoc-plugin</artifactId>
+      <version>2.9.1</version>
+      <executions>
+        <execution>
+          <id>attach-javadocs</id>
+          <goals>
+            <goal>jar</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,110 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.clever</groupId>
-  <artifactId>clever-java-client</artifactId>
+  <groupId>com.clever</groupId>
+  <artifactId>client</artifactId>
   <packaging>jar</packaging>
-  <name>clever-java-client</name>
-  <version>0.1.1</version>
+  <name>Clever Java Client</name>
+  <description>Client Library for the Clever API</description>
+  <url>http://www.clever.com</url>
+  <version>0.2.1</version>
   <prerequisites>
     <maven>2.2.0</maven>
   </prerequisites>
 
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Clever</name>
+      <email>tech-notify@clever.com</email>
+      <organization>Clever</organization>
+      <organizationUrl>http://www.clever.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+      <connection>scm:git:git@github.com:Clever/clever-java.git</connection>
+      <developerConnection>scm:git:git@github.com:Clever/clever-java.git</developerConnection>
+      <url>github.com/Clever/clever-java</url>
+  </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+           <serverId>ossrh</serverId>
+           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+           <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+    </plugin>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-javadoc-plugin</artifactId>
+      <version>2.9.1</version>
+      <executions>
+        <execution>
+          <id>attach-javadocs</id>
+          <goals>
+            <goal>jar</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This change adds the pom configuration required for publishing to maven central. For more details see http://central.sonatype.org/pages/requirements.html.

It also adds some instructions for actually publishing.