### PR TITLE
no docker build needed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,10 +9,3 @@ compile:
 test:
   override:
   - make test
-deployment:
-  all:
-    branch: master
-    owner: Clever
-    commands:
-    - $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
-    - $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME


### PR DESCRIPTION
These commands were included in the app template, but aren't needed for a library like this. There's no `Dockerfile` to build, nor Catapult app to publish.